### PR TITLE
Only consider extension tables when joining on pg_extension tables

### DIFF
--- a/seldump/dbreader.py
+++ b/seldump/dbreader.py
@@ -115,17 +115,17 @@ select
     -- extcondition[array_position(extconfig, r.oid)]
     -- but array_position not available < PG 9.5
     (
-        select extcondition[row_number]
+        select e.extcondition[row_number]
         from (
             select unnest, row_number() over ()
-            from (select unnest(extconfig)) t0
+            from (select unnest(e.extconfig)) t0
         ) t1
         where unnest = r.oid
     ) as extcondition
 from pg_class r
 join pg_namespace s on s.oid = r.relnamespace
-left join pg_depend d on d.objid = r.oid and d.deptype = 'e'
-left join pg_extension e on d.refobjid = e.oid
+left join pg_extension ec on r.oid = any(ec.extconfig)
+left join pg_extension e on ec.oid = e.oid
 where r.relkind = any(%(stateless)s)
 and s.nspname != 'information_schema'
 and s.nspname !~ '^pg_'


### PR DESCRIPTION
We have some tables which directly or indirectly depend on `intarray`. Because there's tables within `extconfig`, the subselect in the `SELECT` clause yields a `NULL` while the `extension` is non-null. As a result, seldump was skipping the tables as (presumably) it assumed these table are extension configuration tables, and not tables which simply depend on this extension

This commit adds a join which checks that the table we're considering is actually an extension configuration table, and not a "regular" table that has an extension as a dependency.